### PR TITLE
Add flake dependencies for Rust on macOS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,12 +42,16 @@
             just
 
             cargo
-            gcc
 
             clojure
             neil
             git
-          ];
+          ] ++ (lib.optionals (builtins.match ".*-linux" system != null) [
+            gcc
+          ]) ++ (lib.optionals (builtins.match ".*-darwin" system != null) [
+            clang
+            libiconv
+          ]);
 
           version = (builtins.fromTOML (builtins.readFile ./rust/Cargo.toml)).package.version;
           limabean-harvest =


### PR DESCRIPTION
Without which  panic unwind fails